### PR TITLE
change to follow python conventions, fix #246 for moderation.py

### DIFF
--- a/minato_namikaze/bot_files/cogs/moderation/moderation.py
+++ b/minato_namikaze/bot_files/cogs/moderation/moderation.py
@@ -4,7 +4,8 @@ from typing import Optional, Union
 import re
 
 import discord
-from discord.ext import *
+from discord.ext import commands
+import datetime
 
 from ...lib import (
     ErrorEmbed,
@@ -16,8 +17,7 @@ from ...lib import (
     return_warning_channel,
     Arguments,
     PostStats,
-    create_paginator,
-
+    create_paginator
     )
 
 
@@ -379,7 +379,9 @@ class Moderation(commands.Cog):
         embed = discord.Embed(title="New Members", colour=discord.Colour.green())
 
         for member in members:
-            body = f"Joined {time.format_relative(member.joined_at)}\nCreated {time.format_relative(member.created_at)}"
+            joined = member.joined_at.strftime('%a, %d %B %Y %I:%M:%S %fms %Z')
+            created = member.created_at.strftime('%a, %d %B %Y %I:%M:%S %fms %Z')
+            body = f"Joined: {joined}\nCreated: {created}"
             embed.add_field(name=f"{member} (ID: {member.id})", value=body, inline=False)
 
         await ctx.send(embed=embed)


### PR DESCRIPTION
changes include:

- variable names and spacings to follow python conventions
- fixes to grammatical errors
- added documentation for further clarity of what commands are for
- this PR also fixes the issues addressed in #246 for the `moderation.py` file