### PR TITLE
Change default unit for weather command

### DIFF
--- a/minato_namikaze/cogs/weather.py
+++ b/minato_namikaze/cogs/weather.py
@@ -119,7 +119,7 @@ class Weather(commands.Cog):
     ) -> None:
         guild = ctx.message.guild
         author = ctx.message.author
-        units = choice(["kelvin", "imperial", "metric"])
+        units = "metric"
         params = {"appid": Tokens.weather.value, "units": units}
         if units == "kelvin":
             params["units"] = "metric"


### PR DESCRIPTION
Changes the default unit for the weather command, from a random choice between K, °C, and °F, to just °C
It makes more sense to use one fixed unit, and could potentially cause confusion between the different units when it is randomly chosen