### PR TITLE
Potential fix for code scanning alert no. 12078: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: Python application
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Creatrix-Net/yondaime-hokage/security/code-scanning/12078](https://github.com/Creatrix-Net/yondaime-hokage/security/code-scanning/12078)

To fix the issue, add a `permissions` block to the root of the workflow file. This block will explicitly define the permissions required for the workflow, limiting the `GITHUB_TOKEN` to read-only access to repository contents. Since the workflow does not perform any write operations, the `contents: read` permission is sufficient.

The `permissions` block should be added immediately after the `name` field in the workflow file. This ensures that the permissions apply to all jobs in the workflow unless overridden by job-specific permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
